### PR TITLE
Add bincode support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["algorithms", "cryptography"]
 [dependencies]
 rayon = { version = "1", optional = true }
 blake3 = "1"
-camino = { version = "1", features = [ "serde1" ] }
+camino = { version = "1" }
 sha2 = { version = "0.10", default-features = false, optional = true }
 bincode = { version = "2.0.1", features = [ "serde" ], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ categories = ["algorithms", "cryptography"]
 [dependencies]
 rayon = { version = "1", optional = true }
 blake3 = "1"
-camino = "1"
+camino = { version = "1", features = [ "serde1" ] }
 sha2 = { version = "0.10", default-features = false, optional = true }
+bincode = { version = "2.0.1", features = [ "serde" ] }
 
 [features]
 default = ["parallel", "encode"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rayon = { version = "1", optional = true }
 blake3 = "1"
 camino = { version = "1", features = [ "serde1" ] }
 sha2 = { version = "0.10", default-features = false, optional = true }
-bincode = { version = "2.0.1", features = [ "serde" ] }
+bincode = { version = "2.0.1", features = [ "serde" ], optional = true }
 
 [features]
 default = ["parallel", "encode"]
@@ -27,3 +27,4 @@ parallel = ["rayon"]
 sha = ["sha2"]
 retain = []
 encode = []
+bincode = [ "dep:bincode", "camino/serde1" ]

--- a/src/components/merkle_item.rs
+++ b/src/components/merkle_item.rs
@@ -1,11 +1,12 @@
 use std::cmp::Ordering;
+use bincode::{Decode, Encode};
 #[cfg(feature = "retain")]
 use std::collections::BTreeSet;
 
 use crate::components::merkle_path::MerklePath;
 
 /// Holds the path, hash and children paths of a file or directory
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Decode, Encode)]
 pub struct MerkleItem {
     pub path: MerklePath,
     pub hash: Vec<u8>,

--- a/src/components/merkle_item.rs
+++ b/src/components/merkle_item.rs
@@ -1,12 +1,16 @@
 use std::cmp::Ordering;
+
+#[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
+
 #[cfg(feature = "retain")]
 use std::collections::BTreeSet;
 
 use crate::components::merkle_path::MerklePath;
 
 /// Holds the path, hash and children paths of a file or directory
-#[derive(Eq, PartialEq, Clone, Debug, Hash, Decode, Encode)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct MerkleItem {
     pub path: MerklePath,
     pub hash: Vec<u8>,

--- a/src/components/merkle_path.rs
+++ b/src/components/merkle_path.rs
@@ -1,15 +1,17 @@
 use std::cmp::Ordering;
 
+#[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
 use camino::Utf8PathBuf;
 
 /// A utility struct that contains an absolute path and a relative path
-#[derive(Eq, PartialEq, Clone, Debug, Hash, Decode, Encode)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct MerklePath {
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub relative: Utf8PathBuf,
     
-    #[bincode(with_serde)]
+    #[cfg_attr(feature = "bincode", bincode(with_serde))]
     pub absolute: Utf8PathBuf,
 }
 

--- a/src/components/merkle_path.rs
+++ b/src/components/merkle_path.rs
@@ -1,11 +1,15 @@
 use std::cmp::Ordering;
 
+use bincode::{Decode, Encode};
 use camino::Utf8PathBuf;
 
 /// A utility struct that contains an absolute path and a relative path
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Decode, Encode)]
 pub struct MerklePath {
+    #[bincode(with_serde)]
     pub relative: Utf8PathBuf,
+    
+    #[bincode(with_serde)]
     pub absolute: Utf8PathBuf,
 }
 

--- a/src/tree/merkle_node.rs
+++ b/src/tree/merkle_node.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fs;
 
+use bincode::{Decode, Encode};
 use camino::Utf8PathBuf;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -12,7 +13,7 @@ use crate::error::IndexingError;
 use crate::utils::algorithm::Algorithm;
 
 /// Represents a single node on the merkle tree
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Decode, Encode)]
 pub struct MerkleNode {
     pub item: MerkleItem,
     pub children: BTreeSet<MerkleNode>,

--- a/src/tree/merkle_node.rs
+++ b/src/tree/merkle_node.rs
@@ -1,9 +1,11 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fs;
-
-use bincode::{Decode, Encode};
 use camino::Utf8PathBuf;
+
+#[cfg(feature = "bincode")]
+use bincode::{Decode, Encode};
+
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -13,7 +15,8 @@ use crate::error::IndexingError;
 use crate::utils::algorithm::Algorithm;
 
 /// Represents a single node on the merkle tree
-#[derive(Eq, PartialEq, Debug, Clone, Decode, Encode)]
+#[derive(Eq, PartialEq, Debug, Clone)]
+#[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct MerkleNode {
     pub item: MerkleItem,
     pub children: BTreeSet<MerkleNode>,

--- a/src/tree/merkle_tree.rs
+++ b/src/tree/merkle_tree.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "bincode")]
 use bincode::{Decode, Encode};
+
 use crate::components::merkle_item::MerkleItem;
 use crate::iters::merkle_node_into_iter::MerkleNodeIntoIter;
 use crate::iters::merkle_node_iter::MerkleNodeIter;
@@ -7,7 +9,7 @@ use crate::tree::merkle_tree_builder::MerkleTreeBuilder;
 use crate::utils::algorithm::Algorithm;
 
 /// Represents an indexed directory tree
-#[derive(Encode, Decode)]
+#[cfg_attr(feature = "bincode", derive(Decode, Encode))]
 pub struct MerkleTree {
     pub root: MerkleNode,
 }

--- a/src/tree/merkle_tree.rs
+++ b/src/tree/merkle_tree.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use crate::components::merkle_item::MerkleItem;
 use crate::iters::merkle_node_into_iter::MerkleNodeIntoIter;
 use crate::iters::merkle_node_iter::MerkleNodeIter;
@@ -6,6 +7,7 @@ use crate::tree::merkle_tree_builder::MerkleTreeBuilder;
 use crate::utils::algorithm::Algorithm;
 
 /// Represents an indexed directory tree
+#[derive(Encode, Decode)]
 pub struct MerkleTree {
     pub root: MerkleNode,
 }


### PR DESCRIPTION
Hiya,

I have a use case for `merkle_hash` to save the output of the algorithm into a binary file. I found [bincode](https://github.com/bincode-org/bincode) which looks to be useful for encoding `MerkleNode` into something that's easy to write to a file, so this PR is for adding the `Encode` and `Decode` traits to the pertinent structs.

I'm in the process of testing this with my project but in the meantime do you have any feedback?